### PR TITLE
allow interactsh host to be changed on "Server Unavailable" error

### DIFF
--- a/src/components/appLoader/index.tsx
+++ b/src/components/appLoader/index.tsx
@@ -12,7 +12,7 @@ interface AppLoaderP {
 const AppLoader = ({ isRegistered, mode }: AppLoaderP) => (
   <div
     className="loader_container"
-    style={{ opacity: isRegistered ? 0 : 1, visibility: isRegistered ? "hidden" : "visible" }}
+    style={{ opacity: isRegistered ? 0 : 1, visibility: isRegistered ? "hidden" : "visible", zIndex: (mode === "loading") ? 110 : 10}}
   >
     <div className="loader_content">
       {mode === "loading" ? (

--- a/src/components/appLoader/styles.scss
+++ b/src/components/appLoader/styles.scss
@@ -17,7 +17,6 @@
 .loader_container {
   position: fixed;
   inset: 0;
-  z-index: 110;
   height: 100vh;
   width: 100vw;
   background: #000 !important;


### PR DESCRIPTION
When the currently configured host is down, settings are cleared from localStorage falling back to default host (`interactsh.com`).

If the default host is the one down, it stays on the `Server Unavailable` screen without ever displaying the header and allowing different host to be (or reset).

With this small change, zIndex from loading-container falls to the same as the header when the error message is shown (=no longer loading), displaying the option to change the host.