### PR TITLE
Add support for custom cidl/cidn

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ If you want to avoid the registration of your server host and token, you can giv
 For this, just specify
 - `REACT_APP_HOST` for the host (default: "oast.fun")
 - `REACT_APP_TOKEN` for the custom token (default: "")
-
+- `REACT_APP_CIDL` for the custom correlation id length (default: 20)
+- `REACT_APP_CIDN` for the custom correlation nonce length (default: 13)
 
 <div align="center">
 

--- a/src/components/customHost/styles.scss
+++ b/src/components/customHost/styles.scss
@@ -150,5 +150,20 @@
         }
       }
     }
+    .advanced_options {
+      display: flex;
+      align-items: left;
+      justify-content: left;
+      span {
+        width: 250px;
+        font-size: 1.6rem;
+        color: #ffffff;
+        letter-spacing: 0;
+        margin-top: 0.7rem;
+      }
+      input {
+        margin-left: 1rem;
+      }
+    }
   }
 }

--- a/src/components/resetPopup/index.tsx
+++ b/src/components/resetPopup/index.tsx
@@ -27,6 +27,7 @@ const ResetPopup = ({ handleCloseDialog }: CustomHostP) => {
           localStorage.clear();
           writeStoredData(d);
           handleCloseDialog();
+          window.location.reload();
         })
         .catch(() => {
           setIsLoading(false);

--- a/src/lib/localStorage/index.ts
+++ b/src/lib/localStorage/index.ts
@@ -11,6 +11,8 @@ export const defaultStoredData: StoredData = {
   privateKey: "",
   publicKey: "",
   correlationId: "",
+  correlationIdLength: process.env.REACT_APP_CIDL ? +process.env.REACT_APP_CIDL : 20,
+  correlationIdNonceLength: process.env.REACT_APP_CIDN ? +process.env.REACT_APP_CIDN : 13,  
   secretKey: "",
   data: [],
   aesKey: "",

--- a/src/lib/types/storedData.ts
+++ b/src/lib/types/storedData.ts
@@ -20,6 +20,8 @@ export const StoredData_ = summon((F) =>
       view: View(F),
       increment: F.number(),
       correlationId: F.string(),
+      correlationIdLength: F.number(),
+      correlationIdNonceLength: F.number(),
       theme: ThemeName(F),
 
       publicKey: F.string(),

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -51,3 +51,17 @@ export const capitalize = flow(
     f.uncurry2
   )
 );
+
+export const generateRandomString = (length: number, lettersOnly: boolean = false) => {
+  let characters = '';
+  if (lettersOnly) {
+    characters = 'abcdefghijklmnopqrstuvwxyz';
+  } else {
+    characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  }
+  let result = '';
+  for (let i = 0; i < length; i+=1) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+};

--- a/src/pages/homePage/index.tsx
+++ b/src/pages/homePage/index.tsx
@@ -82,9 +82,9 @@ const HomePage = () => {
 
   // " Add new tab" function
   const handleAddNewTab = () => {
-    const { increment, host, correlationId } = storedData;
+    const { increment, host, correlationId, correlationIdNonceLength } = storedData;
     const newIncrement = increment + 1;
-    const { url, uniqueId } = generateUrl(correlationId, newIncrement, host);
+    const { url, uniqueId } = generateUrl(correlationId, correlationIdNonceLength, newIncrement, host);
     const tabData: Tab = {
       "unique-id": uniqueId,
       correlationId,


### PR DESCRIPTION
This PR add support for custom cidl/cidn for self-hosted interactsh servers,

You can now configure those options in the interface :

![image](https://github.com/projectdiscovery/interactsh-web/assets/81128827/052b1044-79bf-47db-aeea-91f78528ca0f)

You can also set the defaults as env variable if you selfhost the web app:
- `REACT_APP_CIDL` for the custom correlation id length (default: 20)
- `REACT_APP_CIDN` for the custom correlation nonce length (default: 13)

Feel free to comment on the changes if they don't adhere to React's coding style.