### PR TITLE
Fix issue where web UI stops showing interactions

### DIFF
--- a/src/pages/homePage/index.tsx
+++ b/src/pages/homePage/index.tsx
@@ -207,7 +207,7 @@ const HomePage = () => {
       .then((pollData) => {
         setIsRegistered(true);
         if (pollData?.data?.length !== 0 && !pollData.error) {
-          if (aesKey === "" && pollData.aes_key) {
+          if (pollData.aes_key) {
             decryptedAESKey = decryptAESKey(privateKey, pollData.aes_key);
           }
           const processedData = processData(decryptedAESKey, pollData);
@@ -241,7 +241,8 @@ const HomePage = () => {
           setFilteredData([...newData]);
         }
       })
-      .catch(() => {
+      .catch((error) => {
+        console.log(error);
         setLoaderAnimationMode("server_error");
         setIsRegistered(false);
       });


### PR DESCRIPTION
When the locally stored key expires (but is still present in local storage) the interface stops displaying new interactions because decryption fails. The interface refreshes and there will be absolutely no indicator of a lost interaction. With this change the key included in the payload is used. The behaviour *seems* to be aligned with what the command line client does. Additionally, we log errors instead of swallowing them silently.

The issue was discussed shortly here: https://discord.com/channels/695645237418131507/1438554105772507166