### PR TITLE
Solve race condition that causes the solution to not respect CIDN and CIDL as described in Issue 229

### DIFF
--- a/src/components/customHost/index.tsx
+++ b/src/components/customHost/index.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { ArrowRightIcon, CloseIcon, LoaderIcon } from '@/components/icons';
 import { register } from '@/lib';
-import { defaultStoredData, getStoredData, writeStoredData } from '@/lib/localStorage';
+import { defaultStoredData, flushStoredData, getStoredData, writeStoredData } from '@/lib/localStorage';
 import './styles.scss';
 
 interface CustomHostP {
@@ -61,6 +61,7 @@ const CustomHost = ({ handleCloseDialog }: CustomHostP) => {
           correlationIdLength: correlationIdLengthInputValue,
           correlationIdNonceLength: correlationIdNonceLengthInputValue,
         });
+        flushStoredData();
         register(
           inputValue.replace(/(^\w+:|^)\/\//, ''),
           tokenInputValue,


### PR DESCRIPTION
Change from getStoredData to flushStoredData in order to avoid race condition that makes cidl and cidn not register correctly when using the UI.

It has been tested locally and resolves the issue, by using flushStoredData instead of getStoredData.

This pull request resolves this issue: 
[Issue 229](https://github.com/projectdiscovery/interactsh-web/issues/229)

PS: I tried to find any tests that need to be ran, but did not find anything except the "build for production"-commands. I found an issue with problematic JSON response from server to the UI, but I cannot understand that it is related to this change. Open to input on this!