### PR TITLE
fix: add HTTPS protocol support to web client

### DIFF
--- a/src/components/detailedRequest/index.tsx
+++ b/src/components/detailedRequest/index.tsx
@@ -58,10 +58,10 @@ const DetailedRequest = memo(({ title, data, view, protocol }: DetailedRequestP)
           Copy <CopyIcon />
         </button>
         <div className="pre_wrapper">
-          <pre className={protocol === 'http' ? 'language-http' : 'default'}>
+          <pre className={protocol === 'http' || protocol === 'https' ? 'language-http' : 'default'}>
             <code
               ref={codeRef}
-              className={protocol === 'http' ? 'language-http' : 'default'}
+              className={protocol === 'http' || protocol === 'https' ? 'language-http' : 'default'}
             >
               {data}
             </code>

--- a/src/lib/localStorage/index.ts
+++ b/src/lib/localStorage/index.ts
@@ -58,7 +58,11 @@ export const getStoredData = (): StoredData => {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
-      return { ...defaultStoredData, ...parsed };
+      return {
+        ...defaultStoredData,
+        ...parsed,
+        filter: { ...defaultStoredData.filter, ...parsed.filter },
+      };
     }
   } catch (error) {
     console.error('Failed to read from localStorage:', error);

--- a/src/lib/types/filter.ts
+++ b/src/lib/types/filter.ts
@@ -5,6 +5,7 @@ export type Filter = Record<Protocol, boolean>;
 export const defaultFilter: Filter = {
   dns: true,
   http: true,
+  https: true,
   smtp: true,
 };
 

--- a/src/lib/types/protocol.ts
+++ b/src/lib/types/protocol.ts
@@ -1,4 +1,4 @@
-export const protocols = ['dns', 'http', 'smtp'] as const;
+export const protocols = ['dns', 'http', 'https', 'smtp'] as const;
 export type Protocol = (typeof protocols)[number];
 
 export const Protocol = {


### PR DESCRIPTION
## Summary
- The interactsh server emits `"https"` as a distinct protocol since [projectdiscovery/interactsh@aab1b78](https://github.com/projectdiscovery/interactsh/commit/aab1b78), but the web client only recognized `"dns"`, `"http"`, and `"smtp"`
- HTTPS interactions were silently filtered out and never displayed
- Adds `"https"` to the `protocols` array and default filter
- Applies HTTP syntax highlighting for HTTPS request/response detail views
- Merges stored filter with defaults so existing users get the new `"https"` filter key without clearing localStorage

Companion PR for the CLI client: https://github.com/projectdiscovery/interactsh/pull/1359

## Test plan
- [ ] Register with an interactsh server that has TLS enabled
- [ ] Trigger an HTTPS interaction (e.g. `curl https://<url>`)
- [ ] Verify the HTTPS interaction appears in the web dashboard
- [ ] Verify the protocol filter dropdown shows HTTP, HTTPS, DNS, SMTP
- [ ] Verify existing users with old localStorage see HTTPS interactions without clearing data


Made with [Cursor](https://cursor.com)