### PR TITLE
fix: add HTTPS protocol support to web client

### DIFF
--- a/src/lib/types/filter.ts
+++ b/src/lib/types/filter.ts
@@ -5,6 +5,7 @@ export type Filter = Record<Protocol, boolean>;
 export const defaultFilter: Filter = {
   dns: true,
   http: true,
+  https: true,
   smtp: true,
 };
 

--- a/src/lib/types/protocol.ts
+++ b/src/lib/types/protocol.ts
@@ -1,4 +1,4 @@
-export const protocols = ['dns', 'http', 'smtp'] as const;
+export const protocols = ['dns', 'http', 'https', 'smtp'] as const;
 export type Protocol = (typeof protocols)[number];
 
 export const Protocol = {


### PR DESCRIPTION
## Summary

Since [interactsh@aab1b78](https://github.com/projectdiscovery/interactsh/commit/aab1b78) (v1.3.1), the server differentiates HTTP and HTTPS interactions by returning `"https"` in the protocol field. The web client only recognizes `['dns', 'http', 'smtp']`, so HTTPS interactions are silently filtered out by `filterByProtocols` and never displayed.

- Add `'https'` to the `protocols` array in `protocol.ts`
- Add `https: true` to the `defaultFilter` in `filter.ts`

## Test plan

- [ ] Open interactsh-web connected to a v1.3.1+ server
- [ ] Generate a callback URL and make an HTTPS request to it
- [ ] Verify the HTTPS interaction appears in the requests table
- [ ] Verify the HTTPS filter checkbox is present and functional